### PR TITLE
Crash fix when starting up Doom Classic; sprnames list must be NULL-terminated

### DIFF
--- a/doomclassic/doom/info.cpp
+++ b/doomclassic/doom/info.cpp
@@ -40,7 +40,7 @@ If you have questions concerning this license or the applicable additional terms
 
 #include "p_mobj.h"
 
-const char * const sprnames[NUMSPRITES] = {
+const char * const sprnames[NUMSPRITES + 1] = {
     "TROO","SHTG","PUNG","PISG","PISF","SHTF","SHT2","CHGG","CHGF","MISG",
     "MISF","SAWG","PLSG","PLSF","BFGG","BFGF","BLUD","PUFF","BAL1","BAL2",
     "PLSS","PLSE","MISL","BFS1","BFE1","BFE2","TFOG","IFOG","PLAY","POSS",
@@ -54,7 +54,7 @@ const char * const sprnames[NUMSPRITES] = {
     "POL3","POL1","POL6","GOR2","GOR3","GOR4","GOR5","SMIT","COL1","COL2",
     "COL3","COL4","CAND","CBRA","COL6","TRE1","TRE2","ELEC","CEYE","FSKU",
     "COL5","TBLU","TGRN","TRED","SMBT","SMGT","SMRT","HDB1","HDB2","HDB3",
-    "HDB4","HDB5","HDB6","POB1","POB2","BRS1","TLMP","TLP2"
+    "HDB4","HDB5","HDB6","POB1","POB2","BRS1","TLMP","TLP2",(const char * const)NULL
 };
 
 extern "C"

--- a/doomclassic/doom/info.h
+++ b/doomclassic/doom/info.h
@@ -1169,7 +1169,7 @@ typedef struct
 } state_t;
 
 extern const state_t	tempStates[NUMSTATES];
-extern const char * const sprnames[NUMSPRITES];
+extern const char * const sprnames[NUMSPRITES+1];
 
 typedef enum {
     MT_PLAYER,


### PR DESCRIPTION
Fixes a reproducible crash when built with VS2012 Premium in Debug and Retail builds.
