### PR TITLE
Fix Doom 3 BFG's broken Doom 2 MAP33 Betray.

### DIFF
--- a/doomclassic/doom/doomlib.cpp
+++ b/doomclassic/doom/doomlib.cpp
@@ -81,7 +81,7 @@ namespace DoomLib
 		"1: Entryway", "2: Underhalls", "3: The Gantlet", "4: The Focus", "5: The Waste Tunnels", "6: The Crusher", "7: Dead Simple", "8: Tricks and Traps", "9: The Pit", "10: Refueling Base", 
 		"11: Circle of Death", "12: The Factory", "13: Downtown", "14: The Inmost Dens", "15: Industrial Zone", "16: Suburbs", "17: Tenements", "18: The Courtyard", "19: The Citadel", "20: Gotcha!", 
 		"21: Nirvana", "22: The Catacombs", "23: Barrels O' Fun", "24: The Chasm", "25: Bloodfalls", "26: The Abandoned Mines", "27: Monster Condo", "28: The Spirit World", "29: The Living End",
-		"30: Icon of Sin", "31: IDKFA", "32: Keen"
+		"30: Icon of Sin", "31: IDKFA", "32: Keen", "33: Betray"
 	};
 
 	static const char * TNT_MapNames[] = {

--- a/doomclassic/doom/g_game.cpp
+++ b/doomclassic/doom/g_game.cpp
@@ -1210,6 +1210,7 @@ void G_DoCompleted (void)
 			if ( ::g->gamemission == doom2 ) {
 				switch(::g->gamemap)
 				{
+					case  2: ::g->wminfo.next = 32; break; //Fix Doom 3 BFG Edition, MAP02 secret exit to MAP33 Betray
 					case 15: ::g->wminfo.next = 30; break;
 					case 31: ::g->wminfo.next = 31; break;
 				}
@@ -1225,6 +1226,7 @@ void G_DoCompleted (void)
 				{
 					case 31:
 					case 32: ::g->wminfo.next = 15; break;
+					case 33: ::g->wminfo.next =  2; break; //Fix Doom 3 BFG Edition, MAP33 Betray exit back to MAP03
 					default: ::g->wminfo.next = ::g->gamemap;
 				}
 			}

--- a/doomclassic/doom/p_setup.cpp
+++ b/doomclassic/doom/p_setup.cpp
@@ -347,6 +347,14 @@ void P_LoadThings (int lump)
 				break;
 			}
 		}
+		// Do not spawn cool, old monsters if MAP33 Betray needs German censorship. 
+		else 
+		{
+			if (::g->gamemap==33 && mt->type==84) // MAP33 Betray still has Wolf SS
+			{
+				mt->type = 3004; // Former Human instead
+			}
+		}
 		if (spawn == false)
 			break;
 
@@ -680,6 +688,13 @@ P_SetupLevel
 	P_LoadSideDefs (lumpnum+ML_SIDEDEFS);
 
 	P_LoadLineDefs (lumpnum+ML_LINEDEFS);
+	if (::g->gamemode==commercial && map==33) // Doom 3 BFG Edition's MAP33 has a bug with a teleporter missing a tag
+	{
+		for (i=0 ; i<::g->numlines ; i++) {
+			if (::g->lines[i].special==97 && ::g->lines[i].tag==0) // teleporter with missing tag
+				::g->lines[i].tag = 41; 
+		}
+	}
 	P_LoadSubsectors (lumpnum+ML_SSECTORS);
 	P_LoadNodes (lumpnum+ML_NODES);
 	P_LoadSegs (lumpnum+ML_SEGS);

--- a/doomclassic/doom/st_stuff.cpp
+++ b/doomclassic/doom/st_stuff.cpp
@@ -1427,7 +1427,7 @@ CONSOLE_COMMAND_SHIP( idclev, "warp to next level", 0 ) {
 			return;
 		}
 
-		if( map > 32 ) {
+		if( map > 33 ) { //Doom 3 BFG Edition's Doom 2 has MAP33 Betray 
 			map = 1;
 		}
 	}

--- a/doomclassic/doom/wi_stuff.cpp
+++ b/doomclassic/doom/wi_stuff.cpp
@@ -1538,7 +1538,7 @@ void WI_loadData(void)
 
 	if (::g->gamemode == commercial)
 	{
-		::g->NUMCMAPS = 32;
+		::g->NUMCMAPS = 33; //Doom 3 BFG Edition's Doom 2 WAD includes MAP33 Betray
 		::g->lnames = (patch_t **) DoomLib::Z_Malloc(sizeof(patch_t*) * ::g->NUMCMAPS, PU_LEVEL_SHARED, 0);
 		for (i=0 ; i < ::g->NUMCMAPS ; i++)
 		{								


### PR DESCRIPTION
Doom 3 BFG Edition includes an extra secret Doom 2 level called "MAP33: Betray", originally from the Xbox Doom 3 Collector's Edition. It is supposed to be accessed from a secret exit in MAP02. But due to a bug in Doom 3 BFG Edition, that secret exit just takes you to the next level like the normal exit.

Note, Doom 3 BFG Edition does not include the Doom 1 equivalent, E1M10: Sewers.

This patch by Carl Kenner fixes the source code so that:
The secret exit in MAP02 takes you to MAP33 like it's supposed to.
The console command "idclev 33" will also take you there.
The exit in MAP33 takes you back to MAP03.
MAP33 won't crash the game.
MAP33 has the right name when you save the game.
MAP33's bug of the missing teleporter tag near the yellow door is fixed.
The Wolfenstein SS in MAP33 are replaced with Former Humans.

No changes to the WAD files are needed.
